### PR TITLE
Fix nitro group SMARTS representation to avoid explicit valence error

### DIFF
--- a/fundamentals/recursive_smarts.ipynb
+++ b/fundamentals/recursive_smarts.ipynb
@@ -396,8 +396,9 @@
     }
    ],
    "source": [
-    "nitro_smi_list = [\"c1ccccc1[N+2](=O)(=O)\",\"c1ccccc1N([O-])([O-])\",\"c1ccccc1[N+](=O)([O-])\"]\n",
-    "nitro_mol_list = [Chem.MolFromSmiles(x) for x in nitro_smi_list]\n",
+    "nitro_smi_list = [\"c1ccccc1N(=O)(=O)\",\"c1ccccc1[N+2]([O-])([O-])\",\"c1ccccc1[N+](=O)([O-])\"]\n",
+    "# In the following line, \"sanitize = False\" is used to prevent RDKit from altering the nitro groups while parsing the molecule. This allows the three different representations of the nitro group to be preserved and shown. However, the example also works without disabling sanitization.\n",
+    "nitro_mol_list = [Chem.MolFromSmiles(x, sanitize = False) for x in nitro_smi_list]\n",
     "MolsToGridImage(nitro_mol_list)"
    ]
   },
@@ -416,7 +417,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nitro_query = Chem.MolFromSmarts(\"[N;$([N+2](=O)(=O)),$(N([O-])([O-])),$(N(=O)([O-]))]\")"
+    "nitro_query = Chem.MolFromSmarts(\"[N;$([N](=O)(=O)),$([N+2]([O-])([O-])),$([N+](=O)([O-]))]\")"
    ]
   },
   {
@@ -484,7 +485,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR addresses issues with the representation of the nitro group in the example. The three original representations of the nitro group appear incorrect to me, as the total charge on the molecule or functional group (i.e., the sum of the atomic formal charges) is not zero, whereas it should be.

Additionally, the original code triggers the following error when using RDKit 2024.09.4:

`Explicit valence for atom # 6 N, 5, is greater than permitted`

I've modified two of the three representations of the nitro group based on my interpretation of the example.
